### PR TITLE
Add BigchainDB to application section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ A curated list of blockchain-related academic papers.
 - [Blockstack Technical Whitepaper](https://blockstack.org/whitepaper.pdf). Muneeb A., Ryan S., Jude N, Michael F. '17
 - [Storj A Peer-to-Peer Cloud Storage Network](https://storj.io/storj.pdf). Shawn W., Tome B., Josh B.,James P., Gordon H., Patrick G., Philip H., Chris P. '16
 - [IPFS - Content Addressed, Versioned, P2P File System](https://github.com/ipfs/papers/raw/master/ipfs-cap2pfs/ipfs-p2p-file-system.pdf). Benet J. '15
+- [BigchainDB: A Scalable Blockchain Database](https://www.bigchaindb.com/whitepaper/bigchaindb-whitepaper.pdf). McConaghy T, Marques R, Müller A, De Jonghe D, McConaghy T, McMullen G, Henderson R, Bellemare S, Granzotto A. '17
 
 
 ## License


### PR DESCRIPTION
I intentionally used [this url](https://www.bigchaindb.com/whitepaper/) as [this one](https://www.bigchaindb.com/whitepaper/bigchaindb-whitepaper.pdf) is not a living document. What url do you think is the proper one?