### PR TITLE
change link of ripple protocol consensus algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A curated list of blockchain-related academic papers.
 - [Trust Is Risk: A Decentralized Financial Trust Platform](http://fc17.ifca.ai/preproceedings/paper_37.pdf). Thyfronitis Litos OS, Zindros D. FC '17.
 - [Trust in decentralized anonymous marketplaces](http://dspace.lib.ntua.gr/bitstream/handle/123456789/43147/pseudonymous-trust-2.pdf?sequence=1). Zindros D. '15.
 - [Money as IOUs in social trust networks & a proposal for a decentralized currency network protocol](http://library.uniteddiversity.coop/Money_and_Economics/decentralizedcurrency.pdf). Fugger R. '04.
-- [The Ripple protocol consensus algorithm](http://www.the-blockchain.com/docs/Ripple%20Consensus%20Whitepaper.pdf). Schwartz D, Youngs N, Britto A. '14.
+- [The Ripple protocol consensus algorithm](https://ripple.com/files/ripple_consensus_whitepaper.pdf). Schwartz D, Youngs N, Britto A. '14.
 - [The stellar consensus protocol: A federated model for internet-level consensus](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.696.93&amp=&rep=rep1&amp=&type=pdf). Mazières D. '15.
 - [There’s No Free Lunch, Even Using Bitcoin: Tracking the Popularity and Profits of Virtual Currency Scams](http://fc15.ifca.ai/preproceedings/paper_75.pdf). Vasek M, Moore T. FC '15.
 - [Challenges and Opportunities Associated with a Bitcoin-based Transaction Rating System](http://fc14.ifca.ai/bitcoin/papers/bitcoin14_submission_5.pdf). Vandervort D. FC '14.


### PR DESCRIPTION
<!--
  Hi there! Thank you for submitting a PR!

  Before submitting, let's make sure of a few things.
  Please ensure the following boxes are ticked if they apply.
  If they do not, please try and fulfill them first.
-->

<!-- Checked checkbox should look like this: [x] -->

## Checklist for submitting a pull request to `blockchain-papers`:

- [X] I have carefully **read and comply** with the [Contributing Guidelines](https://github.com/decrypto-org/blockchain-papers/blob/master/CONTRIBUTING.md) of this repo.
- [X] I have **searched** the [PRs](https://github.com/decrypto-org/blockchain-papers/pulls) of this repo and believe that this is not a duplicate.

<!-- 
  Once all boxes are ticked, it would be very helpful if you could fill in the
  following list with the appropriate information.
--> 

- **Title**: The Ripple protocol consensus algorithm
- **Link**: broken link: http://www.the-blockchain.com/docs/Ripple%20Consensus%20Whitepaper.pdf, 
to: https://ripple.com/files/ripple_consensus_whitepaper.pdf

I just changed the broken link of the paper, 'The Ripple protocol consensus algorithm' =), not add a new paper.